### PR TITLE
Add new official languages (nor and ice)

### DIFF
--- a/common/metadata-language-code.md
+++ b/common/metadata-language-code.md
@@ -8,9 +8,9 @@
 
 * Check that exactly one [LanguageCode](#langcode) node exists. If it does:
 
-    * Check that the attribute codeList is "http://www.loc.gov/standards/iso639-2/"
+    * Check that the attribute codeList is "http://www.loc.gov/standards/iso639-2/" (Also the values in https and without the final slash are accepted)
 
-    * Check that the attribute codeListValue is one of the three-letter language codes of the [ISO 639-2/B](./README.md#ref_ISO_639_2) valid for the 24 official EU languages: 'bul', 'hrv', 'cze', 'dan', 'dut', 'eng', 'est', 'fin', 'fre', 'ger', 'gre', 'hun', 'gle', 'ita', 'lav', 'lit', 'mlt', 'pol', 'por', 'rum', 'slo', 'slv', 'spa' or 'swe'.
+    * Check that the attribute codeListValue is one of the three-letter language codes of the [ISO 639-2/B](./README.md#ref_ISO_639_2) valid for the official languages of the Community: 'bul', 'hrv', 'cze', 'dan', 'dut', 'eng', 'est', 'fin', 'fre', 'ger', 'gre', 'hun', 'ice', 'gle', 'ita', 'lav', 'lit', 'mlt', 'nor', 'pol', 'por', 'rum', 'slo', 'slv', 'spa' or 'swe'.
     
 * If any of the checks fails the test fails.
 


### PR DESCRIPTION
Add the new official languages (nor and ice) according to the "Add NOR and ICE as official languages in the TG metadata" issue (https://github.com/INSPIRE-MIF/technical-guidelines/issues/5).